### PR TITLE
Fix spelling of npm and GraphQL

### DIFF
--- a/_includes/layouts/base.njk
+++ b/_includes/layouts/base.njk
@@ -3,7 +3,7 @@
 <head>
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
-  <title>NPM Uninstall Facebook</title>
+  <title>npm Uninstall Facebook</title>
   <style>{% include "assets/css/global.css" %}</style>
   <link rel="apple-touch-icon" sizes="180x180" href="/assets/images/apple-touch-icon.png" />
   <link rel="icon" type="image/png" sizes="32x32" href="/assets/images/favicon-32x32.png" />

--- a/index.md
+++ b/index.md
@@ -1,5 +1,5 @@
 ---
-title: 'NPM Uninstall Facebook'
+title: 'npm Uninstall Facebook'
 layout: 'layouts/home.njk'
 ---
 

--- a/items/graphql.md
+++ b/items/graphql.md
@@ -1,5 +1,5 @@
 ---
-title: 'GraphQl'
+title: 'GraphQL'
 slug: 'graphql'
 alternatives:
   - title: 'JSON:API'


### PR DESCRIPTION
I'd noticed the "GraphQl" typo (title was inconsistent with the description) and figured I might as well fix npm's stylization (they prefer all lowercase) in the process.

PS: I also noticed a few inconsistencies regarding URLs' trailing slashes (e.g. preactjs.com/ vs. svelte.technology) - would that be worth fixing?